### PR TITLE
Fix `tryenv`

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -907,7 +907,7 @@ class WP_Object_Cache {
 	}
 
 	public function tryenv( $envs, $default ) {
-		foreach ( $envs as $env ) {
+		foreach ( (array) $envs as $env ) {
 			$val = getenv( $env );
 			if ( $val ) {
 				return $val;

--- a/object-cache.php
+++ b/object-cache.php
@@ -835,7 +835,7 @@ class WP_Object_Cache {
 	 * @var string
 	 */
 	private $username;
-	
+
 	/**
 	 * Holds the SASL auth password.
 	 *
@@ -864,22 +864,22 @@ class WP_Object_Cache {
 		if ( isset( $memcached_servers ) ) {
 			$this->servers = $memcached_servers;
 		} else {
-			$svrs = explode(',', tryenv( $search_envs_servers, '127.0.0.1:11211' ) );
+			$svrs = explode(',', $this->tryenv( $search_envs_servers, '127.0.0.1:11211' ) );
 			$this->servers = array( );
 			foreach ( $svrs as $srv ) {
 				array_push( $this->servers, explode(':', $srv) );
 			}
 		}
-		
+
 		if ( isset( $memcached_username ) )
 			$this->username = $memcached_username;
 		else
-			$this->username = tryenv( $search_envs_username, NULL );
+			$this->username = $this->tryenv( $search_envs_username, NULL );
 
 		if ( isset( $memcached_password ) )
 			$this->password = $memcached_password;
 		else
-			$this->password = tryenv( $search_envs_password, NULL );
+			$this->password = $this->tryenv( $search_envs_password, NULL );
 
 		$this->m->addServers( $this->servers );
 

--- a/object-cache.php
+++ b/object-cache.php
@@ -864,7 +864,7 @@ class WP_Object_Cache {
 		if ( isset( $memcached_servers ) ) {
 			$this->servers = $memcached_servers;
 		} else {
-			$svrs = explode(',', $this->tryenv( $search_envs_servers, '127.0.0.1:11211' ) );
+			$svrs = explode(',', $this->tryenv( $this->search_envs_servers, '127.0.0.1:11211' ) );
 			$this->servers = array( );
 			foreach ( $svrs as $srv ) {
 				array_push( $this->servers, explode(':', $srv) );
@@ -874,12 +874,12 @@ class WP_Object_Cache {
 		if ( isset( $memcached_username ) )
 			$this->username = $memcached_username;
 		else
-			$this->username = $this->tryenv( $search_envs_username, NULL );
+			$this->username = $this->tryenv( $this->search_envs_username, NULL );
 
 		if ( isset( $memcached_password ) )
 			$this->password = $memcached_password;
 		else
-			$this->password = $this->tryenv( $search_envs_password, NULL );
+			$this->password = $this->tryenv( $this->search_envs_password, NULL );
 
 		$this->m->addServers( $this->servers );
 


### PR DESCRIPTION
Fix these 3 PHP issues:

```
PHP Fatal error:  Uncaught Error: Call to undefined function tryenv()
```

```sh-session
$ wp cache set my_key my_value
PHP Warning:  Invalid argument supplied for foreach() in /app/web/app/object-cache.php on line 910
Warning: Invalid argument supplied for foreach() in /app/web/app/object-cache.php on line 910
PHP Warning:  Invalid argument supplied for foreach() in /app/web/app/object-cache.php on line 910
Warning: Invalid argument supplied for foreach() in /app/web/app/object-cache.php on line 910
PHP Warning:  Invalid argument supplied for foreach() in /app/web/app/object-cache.php on line 910
Warning: Invalid argument supplied for foreach() in /app/web/app/object-cache.php on line 910
```

```
PHP Notice:  Undefined variable: search_envs_servers in /app/web/app/object-cache.php on line 867
Notice: Undefined variable: search_envs_servers in /app/web/app/object-cache.php on line 867
PHP Notice:  Undefined variable: search_envs_username in /app/web/app/object-cache.php on line 877
Notice: Undefined variable: search_envs_username in /app/web/app/object-cache.php on line 877
PHP Notice:  Undefined variable: search_envs_password in /app/web/app/object-cache.php on line 882
Notice: Undefined variable: search_envs_password in /app/web/app/object-cache.php on line 882
```